### PR TITLE
Fixed init_color_roi function in StructureTab.py to be more robust

### DIFF
--- a/src/View/mainpage/StructureTab.py
+++ b/src/View/mainpage/StructureTab.py
@@ -1,6 +1,4 @@
 import csv
-from email.policy import default
-
 import pydicom
 from pathlib import Path
 from PySide6 import QtWidgets, QtGui, QtCore


### PR DESCRIPTION
Fixed init_color_roi function in StructureTab.py to obtain ROI number more safely
Added check to skipt entries where roi number is None
Resolves out of index range when initialising colours for roi structures

## Summary by Sourcery

Improve robustness of init_color_roi by extracting ROI IDs directly from DICOM data and handling missing values, and generate deterministic fallback colors per ROI using numpy RNG.

Enhancements:
- Extract ROI number from 'Referenced ROI Number' field and skip entries with missing IDs
- Use numpy default_rng seeded by ROI ID to generate deterministic fallback colors instead of global seed
- Remove reliance on list_roi_numbers index mapping for ROI number resolution